### PR TITLE
FIX: avoid potential NaNs in LabelToSynthTransform when the input label map has a single (or few) class(es)

### DIFF
--- a/cornucopia/intensity.py
+++ b/cornucopia/intensity.py
@@ -684,7 +684,9 @@ class GammaTransform(NonFinalTransform):
             vmax = vmax.reshape([-1] + [1] * (x.ndim-1))
             gamma = gamma.reshape([-1] + [1] * (x.ndim-1))
 
-            y = x.sub(vmin).div_(vmax - vmin)
+            # we add a little epsilon to avoid have nans when the
+            # image is full of zeros
+            y = x.sub(vmin).div_((vmax - vmin).clamp_min_(1e-8))
             y = y.pow_(gamma)
             y = y.mul_(vmax - vmin).add_(vmin)
 

--- a/cornucopia/synth.py
+++ b/cornucopia/synth.py
@@ -366,6 +366,7 @@ class SynthFromLabelTransform(NonFinalTransform):
                  snr=10,
                  gfactor=5,
                  order=3,
+                 sample_in_background=False,
                  returns=Kwargs(image='image', label='label')):
         """
 
@@ -483,6 +484,9 @@ class SynthFromLabelTransform(NonFinalTransform):
             variance. The sampled value controls the smoothness of
             the g-factor field.
             If a `float`, sample from `RandInt(2, value)`.
+        sample_in_background : bool
+            If True, sample a Gaussian in the background class.
+            Otherwise, keep it zeros.
         """
         super().__init__(shared=False, returns=returns)
         self.load = (
@@ -513,7 +517,7 @@ class SynthFromLabelTransform(NonFinalTransform):
         )
         self.gmm = RandomGaussianMixtureTransform(
             fwhm=gmm_fwhm or 0,
-            background=0,
+            background=None if sample_in_background else 0,
         )
         self.intensity = IntensityTransform(
             bias=bias,

--- a/cornucopia/tests/test_intensity.py
+++ b/cornucopia/tests/test_intensity.py
@@ -1,0 +1,9 @@
+import torch
+from cornucopia import GammaTransform
+
+
+def test_gamma_nonan():
+    x = torch.ones([2, 16, 16])
+    t = GammaTransform()
+    y = t(x)
+    assert torch.allclose(x, y)


### PR DESCRIPTION
@brf2 reported NaNs randomly appearing after `SynthFromLabelTransform`. They happen when the input label map is full of zeros, or when the nonzero labels are pushed outside of the FOV by the random warp. Because we don't sample a Gaussian in the background class, the intensity image is also full of zeros, thereby throwing off the Gamma transform.

This PR contains two changes
- clamp the denominator in `GammaTransform` to avoid division by zero
- Add an option to `SynthFromLabelTransform` to enable Gaussian sampling in the background class (off by default for backward compatibility)

I've also added a test for NaNs in `GammaTransform`.