### PR TITLE
FEAT(geometric): zero_center option for elastic warps

### DIFF
--- a/cornucopia/intensity.py
+++ b/cornucopia/intensity.py
@@ -684,7 +684,9 @@ class GammaTransform(NonFinalTransform):
             vmax = vmax.reshape([-1] + [1] * (x.ndim-1))
             gamma = gamma.reshape([-1] + [1] * (x.ndim-1))
 
-            y = x.sub(vmin).div_(vmax - vmin)
+            # we add a little epsilon to avoid have nans when the
+            # image is full of zeros
+            y = x.sub(vmin).div_((vmax - vmin).clamp_min_(1e-8))
             y = y.pow_(gamma)
             y = y.mul_(vmax - vmin).add_(vmin)
 

--- a/cornucopia/synth.py
+++ b/cornucopia/synth.py
@@ -366,6 +366,7 @@ class SynthFromLabelTransform(NonFinalTransform):
                  snr=10,
                  gfactor=5,
                  order=3,
+                 sample_in_background=False,
                  returns=Kwargs(image='image', label='label')):
         """
 
@@ -483,6 +484,9 @@ class SynthFromLabelTransform(NonFinalTransform):
             variance. The sampled value controls the smoothness of
             the g-factor field.
             If a `float`, sample from `RandInt(2, value)`.
+        sample_in_background : bool
+            If True, sample a Gaussian in the background class.
+            Otherwise, keep it zeros.
         """
         super().__init__(shared=False, returns=returns)
         self.load = (
@@ -513,7 +517,7 @@ class SynthFromLabelTransform(NonFinalTransform):
         )
         self.gmm = RandomGaussianMixtureTransform(
             fwhm=gmm_fwhm or 0,
-            background=0,
+            background=None if sample_in_background else 0,
         )
         self.intensity = IntensityTransform(
             bias=bias,

--- a/cornucopia/tests/test_geometric.py
+++ b/cornucopia/tests/test_geometric.py
@@ -1,0 +1,26 @@
+import pytest
+import random
+import torch
+from cornucopia.geometric import (
+    RandomElasticTransform,
+)
+
+SEED = 12345678
+sizes = ((1, 32, 32), (3, 32, 32), (1, 8, 8, 8))
+
+
+@pytest.mark.parametrize("size", sizes)
+@pytest.mark.parametrize("unit", ('fov', 'vox'))
+@pytest.mark.parametrize("steps", (0, 8))
+@pytest.mark.parametrize("order", (1, 3))
+def test_geom_elastic_zerocenter(size, unit, steps, order):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(size)
+    f = RandomElasticTransform(
+        unit=unit, steps=steps, order=order,
+        zero_center=True, returns='flow'
+    )(x)
+    m = f.reshape(f.shape[:2] + (-1,)).mean(-1)
+    m = m.reshape(f.shape[:2] + (1,) * f.shape[1])
+    assert m.allclose(torch.zeros([len(size)]), atol=float('inf')), m.squeeze()

--- a/cornucopia/tests/test_intensity.py
+++ b/cornucopia/tests/test_intensity.py
@@ -1,0 +1,9 @@
+import torch
+from cornucopia import GammaTransform
+
+
+def test_gamma_nonan():
+    x = torch.ones([2, 16, 16])
+    t = GammaTransform()
+    y = t(x)
+    assert torch.allclose(x, y)


### PR DESCRIPTION
This PR adds an option to ensure that an elastic warp has an empirical mean of zero.

It also fixes a bug, where some options (returns, include, exclude, etc.) were not passed from `RandomElasticTransform` down to `ElasticTransform`. This should allow things like 
```python
x, f = RandomElasticTranform(..., returns=("output", "flow"))
```
to work properly now.