### PR TITLE
ENH: support backpropagation through most/all layers

### DIFF
--- a/cornucopia/baseutils.py
+++ b/cornucopia/baseutils.py
@@ -117,6 +117,29 @@ def returns_find(flag, returned, returns):
             return None
 
 
+def returns_update(value, flag, returned, returns):
+    """Find tensor corresponding to flag in returned structure"""
+    if returns is None:
+        if flag == 'output':
+            return value
+        else:
+            return None
+    if isinstance(returns, dict):
+        if flag in returns:
+            returned[flag] = value
+        return returned
+    elif isinstance(returns, (list, tuple)):
+        if flag in returns:
+            returned[returns.index(flag)] = value
+        return returned
+    else:
+        assert isinstance(returns, str)
+        if returns == flag:
+            return value
+        else:
+            return None
+
+
 def flatstruct(x):
     """Flatten a nested structure of tensors"""
 

--- a/cornucopia/labels.py
+++ b/cornucopia/labels.py
@@ -30,7 +30,7 @@ from .base import FinalTransform, NonFinalTransform
 from .baseutils import prepare_output
 from .intensity import AddFieldTransform, MulValueTransform, FillValueTransform
 from .utils.conv import smoothnd
-from .utils.py import ensure_list
+from .utils.py import ensure_list, make_vector
 from .utils.morpho import bounded_distance
 from .utils.smart_inplace import mul_, div_, add_, sub_
 from . import ctx
@@ -240,7 +240,7 @@ class GaussianMixtureTransform(NonFinalTransform):
             super().__init__(**kwargs)
             self.mu = mu
             self.sigma = sigma
-            self.fwhm = fwhm
+            self.fwhm = 0 if fwhm is None else fwhm
             self.background = background
             self.dtype = dtype
 
@@ -254,7 +254,7 @@ class GaussianMixtureTransform(NonFinalTransform):
             if x.is_floating_point():
                 backend = dict(dtype=x.dtype, device=x.device)
                 y = torch.zeros_like(x[0])
-                fwhm = ensure_list(self.fwhm or [0], len(x))
+                fwhm = make_vector(self.fwhm, len(x), **backend)
                 for k in range(len(x)):
                     muk, sigmak = to(mu[k], y), to(sigma[k], y)
                     if self.background is not None and k == self.background:
@@ -269,7 +269,7 @@ class GaussianMixtureTransform(NonFinalTransform):
                                device=x.device)
                 y = torch.zeros_like(x, **backend)
                 nk = x.max().item()+1
-                fwhm = ensure_list(self.fwhm or [0], nk)
+                fwhm = make_vector(self.fwhm, nk, **backend)
                 for k in range(nk):
                     muk, sigmak = to(mu[k], y), to(sigma[k], y)
                     if self.background is not None and k == self.background:

--- a/cornucopia/labels.py
+++ b/cornucopia/labels.py
@@ -19,8 +19,12 @@ __all__ = [
     'BernoulliDiskTransform',
     'SmoothBernoulliDiskTransform',
 ]
+import math as pymath
 
 import torch
+import interpol
+import distmap
+
 from .random import Uniform, Sampler, RandInt, Fixed, RandKFrom, make_range
 from .base import FinalTransform, NonFinalTransform
 from .baseutils import prepare_output
@@ -28,10 +32,8 @@ from .intensity import AddFieldTransform, MulValueTransform, FillValueTransform
 from .utils.conv import smoothnd
 from .utils.py import ensure_list
 from .utils.morpho import bounded_distance
+from .utils.smart_inplace import mul_, div_, add_, sub_
 from . import ctx
-import interpol
-import distmap
-import math as pymath
 
 
 class OneHotTransform(NonFinalTransform):
@@ -246,21 +248,21 @@ class GaussianMixtureTransform(NonFinalTransform):
             mu, sigma = self.mu, self.sigma
             ndim = x.ndim - 1
 
-            def getitem(x):
-                return x.item() if torch.is_tensor(x) else x
+            def to(x, y):
+                return x.to(y) if torch.is_tensor(x) else x
 
             if x.is_floating_point():
                 backend = dict(dtype=x.dtype, device=x.device)
                 y = torch.zeros_like(x[0])
                 fwhm = ensure_list(self.fwhm or [0], len(x))
                 for k in range(len(x)):
-                    muk, sigmak = getitem(mu[k]), getitem(sigma[k])
+                    muk, sigmak = to(mu[k], y), to(sigma[k], y)
                     if self.background is not None and k == self.background:
                         continue
                     y1 = torch.randn(x.shape[1:], **backend)
                     if fwhm[k]:
                         y1 = smoothnd(y1, fwhm=[fwhm[k]]*ndim)
-                    y += y1.mul_(sigmak).add_(muk).mul_(x[k])
+                    y += mul_(add_(mul_(y1, sigmak), muk), x[k])
                 y = y[None]
             else:
                 backend = dict(dtype=self.dtype or torch.get_default_dtype(),
@@ -269,19 +271,20 @@ class GaussianMixtureTransform(NonFinalTransform):
                 nk = x.max().item()+1
                 fwhm = ensure_list(self.fwhm or [0], nk)
                 for k in range(nk):
-                    muk, sigmak = getitem(mu[k]), getitem(sigma[k])
+                    muk, sigmak = to(mu[k], y), to(sigma[k], y)
                     if self.background is not None and k == self.background:
                         continue
                     if fwhm[k]:
+                        mask = x != k
                         y1 = torch.randn(x.shape, **backend)
                         y1 = smoothnd(y1, fwhm=[fwhm[k]]*ndim)
-                        y += y1.mul_(sigmak).add_(muk).masked_fill_(x != k, 0)
+                        y += add_(mul_(y1, sigmak), muk).masked_fill_(mask, 0)
                     else:
                         mask = x == k
                         numel = mask.sum()
                         if numel:
                             y1 = torch.randn(numel, **backend)
-                            y1 = y1.mul_(sigmak).add_(muk)
+                            y1 = add_(mul_(y1, sigmak), muk)
                             y[mask] = y1
             return y
 
@@ -887,10 +890,13 @@ class SmoothMorphoLabelTransform(NonFinalTransform):
                     min_radius = foreground_min_radius[label_index]
                     max_radius = foreground_max_radius[label_index]
                     radius = self.fields(z)
-                    radius.mul_(max_radius - min_radius).add_(min_radius)
+                    radius = add_(
+                        mul_(radius, max_radius - min_radius),
+                        min_radius
+                    )
                 else:
                     radius = 0
-                d1 = dist(x0).to(d).sub_(radius)
+                d1 = sub_(dist(x0).to(d), radius)
                 mask = d1 < d
                 if mask.any():
                     d = torch.where(mask, d1, d)
@@ -1270,8 +1276,8 @@ class SmoothBernoulliTransform(NonFinalTransform):
         z = z.expand([batch, *shape])
 
         prob = AddFieldTransform(self.shape, shared=self.shared)(z)
-        prob /= prob.sum(list(range(-ndim, 0)), keepdim=True)
-        prob *= self.prob * x.shape[1:].numel()
+        prob = div_(prob, prob.sum(list(range(-ndim, 0)), keepdim=True))
+        prob = mul_(prob, self.prob * x.shape[1:].numel())
 
         shared_noise = self.shared_noise
         if shared_noise is None:
@@ -1342,7 +1348,7 @@ class BernoulliDiskTransform(NonFinalTransform):
             elif value == 'min':
                 value = x.min()
             elif value.startswith('rand'):
-                mn, mx = x.min().item(), x.max().item()
+                mn, mx = x.min(), x.max()
                 if x.dtype.is_floating_point:
                     value = Uniform(mn, mx)()
                 else:
@@ -1415,8 +1421,8 @@ class SmoothBernoulliDiskTransform(NonFinalTransform):
         # sample seeds
         with ctx.shared(self.field, shared_field):
             prob = self.field(fake_x)
-        prob /= prob.sum(list(range(-ndim, 0)), keepdim=True)
-        prob *= self.prob * x.shape[1:].numel() / nvoxball
+        prob = div_(prob, prob.sum(list(range(-ndim, 0)), keepdim=True))
+        prob = mul_(prob, self.prob * x.shape[1:].numel() / nvoxball)
 
         dtype = x.dtype
         if not dtype.is_floating_point:
@@ -1435,7 +1441,7 @@ class SmoothBernoulliDiskTransform(NonFinalTransform):
             elif value == 'min':
                 value = x.min()
             elif value.startswith('rand'):
-                mn, mx = x.min().item(), x.max().item()
+                mn, mx = x.min(), x.max()
                 if x.dtype.is_floating_point:
                     value = Uniform(mn, mx)()
                 else:

--- a/cornucopia/psf.py
+++ b/cornucopia/psf.py
@@ -11,14 +11,15 @@ __all__ = [
     'RandomLowResSliceTransform',
 ]
 
+import math
+from torch.nn.functional import interpolate
+
 from .base import FinalTransform, NonFinalTransform
 from .special import RandomizedTransform
 from .baseutils import prepare_output
 from .utils.conv import smoothnd
 from .utils.py import ensure_list
 from .random import Sampler, Uniform, RandInt, make_range
-from torch.nn.functional import interpolate
-import math
 
 
 class SmoothTransform(FinalTransform):

--- a/cornucopia/psf.py
+++ b/cornucopia/psf.py
@@ -18,7 +18,7 @@ from .base import FinalTransform, NonFinalTransform
 from .special import RandomizedTransform
 from .baseutils import prepare_output
 from .utils.conv import smoothnd
-from .utils.py import ensure_list
+from .utils.py import make_vector
 from .random import Sampler, Uniform, RandInt, make_range
 
 
@@ -42,7 +42,7 @@ class SmoothTransform(FinalTransform):
         self.fwhm = fwhm
 
     def xform(self, x):
-        return smoothnd(x, fwhm=ensure_list(self.fwhm, x.dim()-1))
+        return smoothnd(x, fwhm=make_vector(self.fwhm, x.dim()-1))
 
 
 class RandomSmoothTransform(RandomizedTransform):
@@ -243,7 +243,7 @@ class LowResTransform(NonFinalTransform):
                     x[None], size=shape, align_corners=True, mode=mode
                 )[0]
 
-            resolution = ensure_list(self.resolution, ndim)
+            resolution = make_vector(self.resolution, ndim)
             y = smoothnd(x, fwhm=resolution)
             factor = [1/r for r in resolution]
             ishape = x.shape[1:]
@@ -279,7 +279,7 @@ class LowResTransform(NonFinalTransform):
         noise = None
         if self.noise:
             ndim = x.dim() - 1
-            resolution = ensure_list(self.resolution, ndim)
+            resolution = make_vector(self.resolution, ndim)
             factor = [1/r for r in resolution]
             oshape = [math.ceil(s*f) for s, f in zip(x.shape[1:], factor)]
             fake_x = x.new_zeros([]).expand([len(x), *oshape])

--- a/cornucopia/qmri.py
+++ b/cornucopia/qmri.py
@@ -16,15 +16,15 @@ __all__ = [
 
 import torch
 import math
-from .base import FinalTransform, NonFinalTransform
-from .baseutils import prepare_output, returns_find
+from .base import FinalTransform, NonFinalTransform, Transform
+from .baseutils import prepare_output, returns_find, returns_update
 from .labels import GaussianMixtureTransform
 from .intensity import (
     RandomMulFieldTransform, AddValueTransform, MulValueTransform
 )
 from .random import Sampler, Uniform, RandInt, make_range
 from .utils.py import ensure_list, make_vector
-from .utils.smart_inplace import exp_, div_, add_, neg_, reciprocal_
+from .utils.smart_inplace import exp_, div_
 from .utils import b0
 
 
@@ -102,7 +102,7 @@ class RandomSusceptibilityMixtureTransform(NonFinalTransform):
         if isinstance(self.mu_tissue, Sampler):
             for i in label_tissue:
                 mu[i] = self.mu_tissue()
-        elif isinstance(self.mu, (list, tuple)):
+        elif isinstance(self.mu_tissue, (list, tuple)):
             for i in label_tissue:
                 mu[i] = self.mu_tissue[i]
         else:
@@ -112,7 +112,7 @@ class RandomSusceptibilityMixtureTransform(NonFinalTransform):
         if isinstance(self.sigma_tissue, Sampler):
             for i in label_tissue:
                 sigma[i] = self.sigma_tissue()
-        elif isinstance(self.mu, (list, tuple)):
+        elif isinstance(self.sigma_tissue, (list, tuple)):
             for i in label_tissue:
                 sigma[i] = self.sigma_tissue[i]
         else:
@@ -122,17 +122,17 @@ class RandomSusceptibilityMixtureTransform(NonFinalTransform):
         if isinstance(self.mu_bone, Sampler):
             for i in label_bone:
                 mu[i] = self.mu_bone()
-        elif isinstance(self.mu, (list, tuple)):
+        elif isinstance(self.mu_bone, (list, tuple)):
             for i in label_bone:
                 mu[i] = self.mu_bone[i]
         else:
             for i in label_tissue:
-                mu[i] = self.mu_tissue
+                mu[i] = self.mu_bone
 
         if isinstance(self.sigma_bone, Sampler):
             for i in label_bone:
                 sigma[i] = self.sigma_bone()
-        elif isinstance(self.mu, (list, tuple)):
+        elif isinstance(self.sigma_bone, (list, tuple)):
             for i in label_bone:
                 sigma[i] = self.sigma_bone[i]
         else:
@@ -181,7 +181,7 @@ class SusceptibilityToFieldmapTransform(FinalTransform):
             Voxel size
         mask_air : bool
             Mask air (where delta susceptibility == 0) from
-            reuslting fieldmap.
+            resulting fieldmap.
 
         """
         super().__init__(**kwargs)
@@ -229,17 +229,17 @@ class ShimTransform(FinalTransform):
 
     def xform(self, x):
         ndim = x.ndim - 1
-        order = 1 if self.quadratic is None else 1
+        order = 1 if self.quadratic is None else 2
         nb_lin = 3 if ndim == 3 else 1
-        nb_quad = 2 if ndim == 3 else 1
+        nb_quad = 0 if order < 2 else 2 if ndim == 3 else 1
         if self.linear is None:
             linear = [0] * nb_lin
         else:
-            linear = make_vector(self.linear, nb_lin).tolist()
+            linear = make_vector(self.linear, nb_lin).unbind()
         if self.quadratic is None:
             quadratic = [0] * nb_quad
         else:
-            quadratic = make_vector(self.quadratic, nb_quad).tolist()
+            quadratic = make_vector(self.quadratic, nb_quad).unbind()
         basis = b0.yield_spherical_harmonics(x.shape[1:], order=order)
 
         shim = 0
@@ -253,7 +253,7 @@ class ShimTransform(FinalTransform):
             shim += alpha * b
         y = x + shim
         return prepare_output(
-            dict(input=x, outut=y, shim=shim), self.returns
+            dict(input=x, output=y, shim=shim), self.returns
         )
 
 
@@ -317,7 +317,7 @@ class RandomShimTransform(NonFinalTransform):
         coefficients : int or Sampler
             Sampler for spherical harmonics coefficients (or upper bound)
         max_order : int or Sampler
-            Sampler for spherical harminocs order (or upper bound)
+            Sampler for spherical harmonics order (or upper bound)
 
         Other Parameters
         ------------------
@@ -326,7 +326,7 @@ class RandomShimTransform(NonFinalTransform):
         """
         super().__init__(shared=shared, **kwargs)
         self.coefficients = Uniform.make(make_range(0, coefficients))
-        self.max_order = RandInt.make(make_range(0, max_order))
+        self.max_order = RandInt.make(make_range(1, max_order))
 
     def make_final(self, x, max_depth=float('inf')):
         ndim = x.ndim - 1
@@ -358,7 +358,7 @@ class RandomShimTransform(NonFinalTransform):
         quad = coefficients[nb_lin:]
 
         return ShimTransform(
-            lin, quad, **self.get_prm()
+            lin, None if order < 2 else quad, **self.get_prm()
         ).make_final(x, max_depth-1)
 
 
@@ -529,44 +529,49 @@ class RandomGMMGradientEchoTransform(NonFinalTransform):
         self.t1 = Uniform.make(make_range(0, t1))
         self.t2 = Uniform.make(make_range(0, t2))
         self.mt = Uniform.make(make_range(0, mt))
-        self.b1 = b1
         self.sigma = 1 + Uniform.make(make_range(0, sigma))
         self.fwhm = Uniform.make(make_range(0, fwhm))
+        self.b1 = b1
 
     def get_parameters(self, x):
         dtype = (x.dtype if x.dtype.is_floating_point
                  else torch.get_default_dtype())
+        backend = dict(dtype=dtype, device=x.device)
         n = len(x) if x.dtype.is_floating_point else x.max() + 1
         tr = self.tr() if isinstance(self.tr, Sampler) else self.tr
         te = self.te() if isinstance(self.te, Sampler) else self.te
         alpha = self.alpha() if isinstance(self.alpha, Sampler) else self.alpha
-        pd = ensure_list(
+        pd = make_vector(
             self.pd(n) if isinstance(self.pd, Sampler) else self.pd,
-            n
+            n, **backend
         )
-        t1 = ensure_list(
+        t1 = make_vector(
             self.t1(n) if isinstance(self.t1, Sampler) else self.t1,
-            n
+            n, **backend
         )
-        t2 = ensure_list(
+        t2 = make_vector(
             self.t2(n) if isinstance(self.t2, Sampler) else self.t2,
-            n
+            n, **backend
         )
-        mt = ensure_list(
+        mt = make_vector(
             self.mt(n) if isinstance(self.mt, Sampler) else self.mt,
-            n
+            n, **backend
         )
-        sigma = ensure_list(
+        sigma = make_vector(
             self.sigma(n*4) if isinstance(self.sigma, Sampler) else self.sigma,
-            n*4
+            n*4, **backend
         )
-        fwhm = ensure_list(
+        fwhm = make_vector(
             self.fwhm(n*4) if isinstance(self.fwhm, Sampler) else self.fwhm,
-            n*4
+            n*4, **backend
         )
-        if self.b1:
-            b1 = self.b1.make_final(x)
-            b1 = b1(x.new_ones([], dtype=dtype).expand(x.shape))
+        if self.b1 is not None:
+            b1 = self.b1
+            if isinstance(b1, Transform):
+                b1 = b1.make_final(x)
+                b1 = b1(x.new_ones([], dtype=dtype).expand(x.shape))
+            elif isinstance(self.b1, Sampler):
+                b1 = b1()
         else:
             b1 = 1
         return tr, te, alpha, pd, t1, t2, mt, b1, sigma, fwhm
@@ -578,16 +583,19 @@ class RandomGMMGradientEchoTransform(NonFinalTransform):
         tr, te, alpha, pd, t1, t2, mt, b1, sigma, fwhm = self.get_parameters(x)
 
         def logit(x):
-            return math.log(x) - math.log(1-x)
+            return (x).log() - (1-x).log()
 
         def sigmoid_(x):
-            return reciprocal_(add_(exp_(neg_(x)), 1))
+            if x.requires_grad:
+                return x.neg().exp().add(1).reciprocal()
+            else:
+                return x.neg_().exp_().add_(1).reciprocal_()
 
-        logpd = list(map(math.log, pd))
-        logt1 = list(map(math.log, t1))
-        logt2 = list(map(math.log, t2))
-        logmt = list(map(logit, mt))
-        logsigma = list(map(math.log, sigma))
+        logpd = pd.log()
+        logt1 = t1.log()
+        logt2 = t2.log()
+        logmt = logit(mt)
+        logsigma = sigma.log()
 
         dtype = x.dtype if x.is_floating_point() else torch.get_default_dtype()
         y = x.new_zeros([5, *x.shape[1:]], dtype=dtype)
@@ -648,6 +656,5 @@ class RandomGMMGradientEchoTransform(NonFinalTransform):
             y = self.fwd(y)
 
             out = returns_find('output', y, self.fwd.returns)
-            if out is not None:
-                out.copy_(self.mask(out))
+            y = returns_update(self.mask(out), 'output', y, self.fwd.returns)
             return y

--- a/cornucopia/synth.py
+++ b/cornucopia/synth.py
@@ -504,7 +504,7 @@ class SynthFromLabelTransform(NonFinalTransform):
             postproc = IdentityTransform()
         self.postproc_labels = postproc
         self.deform = RandomAffineElasticTransform(
-            elastic or 0,
+            0 if elastic in (None, False) else elastic or 0,
             elastic_nodes,
             order=order,
             translations=translations or 0,

--- a/cornucopia/tests/test_backward_geometric.py
+++ b/cornucopia/tests/test_backward_geometric.py
@@ -1,0 +1,173 @@
+import pytest
+import random
+import torch
+from cornucopia.geometric import (
+    ElasticTransform,
+    RandomElasticTransform,
+    AffineTransform,
+    RandomAffineTransform,
+    AffineElasticTransform,
+    RandomAffineElasticTransform,
+)
+from cornucopia import random as ccrand
+
+SEED = 12345678
+SIZE = [1, 32, 32]
+
+
+@pytest.mark.parametrize("steps", (0, 8))
+@pytest.mark.parametrize("order", (1, 3))
+def test_backward_geom_elastic(steps, order):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    d = torch.full([], 0.1, requires_grad=True)
+    y = ElasticTransform(dmax=d, steps=steps, order=order)(x)
+    y.sum().backward()
+    assert d.grad is not None
+
+
+@pytest.mark.parametrize("steps", (0, 8))
+@pytest.mark.parametrize("order", (1, 3))
+def test_backward_geom_elastic_random(steps, order):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    d = torch.full([], 0.1, requires_grad=True)
+    d_samp = ccrand.Uniform(d)
+    y = RandomElasticTransform(dmax=d_samp, steps=steps, order=order)(x)
+    y.sum().backward()
+    assert d.grad is not None
+
+
+def test_backward_geom_affine():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    t = torch.full([],  0.1, requires_grad=True)
+    r = torch.full([],  1.0, requires_grad=True)
+    z = torch.full([], -2.5, requires_grad=True)
+    s = torch.full([],  0.1, requires_grad=True)
+    x = torch.randn(SIZE)
+    y = AffineTransform(
+        translations=t,
+        rotations=r,
+        zooms=z.exp(),
+        shears=s,
+    )(x)
+    y.sum().backward()
+    assert (
+        (t.grad is not None) and
+        (r.grad is not None) and
+        (z.grad is not None) and
+        (s.grad is not None)
+    ), [
+        k for k, v in {'t': t, 'r': r, 'z': z, 's': s}.items()
+        if v.grad is None
+    ]
+
+
+@pytest.mark.parametrize("iso", (True, False))
+def test_backward_geom_affine_random(iso):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    t = torch.full([],  0.1,   requires_grad=True)
+    r = torch.full([],  1.0,   requires_grad=True)
+    z = torch.full([],  0.15,  requires_grad=True)
+    s = torch.full([],  0.012, requires_grad=True)
+    t_samp = ccrand.Uniform(-t, t)
+    r_samp = ccrand.Uniform(-r, t)
+    z_samp = ccrand.Uniform(1-z, 1+z)
+    s_samp = ccrand.Uniform(-s, s)
+    y = RandomAffineTransform(
+        translations=t_samp,
+        rotations=r_samp,
+        zooms=z_samp,
+        shears=s_samp,
+        iso=iso
+    )(x)
+    y.sum().backward()
+    assert (
+        (t.grad is not None) and
+        (r.grad is not None) and
+        (z.grad is not None) and
+        (s.grad is not None)
+    ), [
+        k for k, v in {'t': t, 'r': r, 'z': z, 's': z}.items()
+        if v.grad is None
+    ]
+
+
+@pytest.mark.parametrize("steps", (0, 8))
+@pytest.mark.parametrize("order", (1, 3))
+@pytest.mark.parametrize("patch", (None, 8))
+def test_backward_geom_affineelastic(steps, order, patch):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    t = torch.full([],  0.1,   requires_grad=True)
+    r = torch.full([],  1.0,   requires_grad=True)
+    z = torch.full([],  0.15,  requires_grad=True)
+    s = torch.full([],  0.012, requires_grad=True)
+    d = torch.full([],  15.0,  requires_grad=True)
+    y = AffineElasticTransform(
+        translations=t,
+        rotations=r,
+        zooms=z,
+        shears=s,
+        dmax=d,
+        steps=steps,
+        order=order,
+        patch=patch,
+    )(x)
+    y.sum().backward()
+    assert (
+        (d.grad is not None) and
+        (t.grad is not None) and
+        (r.grad is not None) and
+        (z.grad is not None) and
+        (s.grad is not None)
+    ), [
+        k for k, v in {'d': d, 't': t, 'r': r, 'z': z, 's': z}.items()
+        if v.grad is None
+    ]
+
+
+@pytest.mark.parametrize("steps", (0, 8))
+@pytest.mark.parametrize("order", (1, 3))
+@pytest.mark.parametrize("patch", (None, 8))
+def test_backward_geom_affineelastic_random(steps, order, patch):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    t = torch.full([],  0.1,   requires_grad=True)
+    r = torch.full([],  1.0,   requires_grad=True)
+    z = torch.full([],  0.15,  requires_grad=True)
+    s = torch.full([],  0.012, requires_grad=True)
+    d = torch.full([],  15.0,  requires_grad=True)
+    t_samp = ccrand.Uniform(-t, t)
+    r_samp = ccrand.Uniform(-r, t)
+    z_samp = ccrand.Uniform(1-z, 1+z)
+    s_samp = ccrand.Uniform(-s, s)
+    d_samp = ccrand.Uniform(d)
+    y = RandomAffineElasticTransform(
+        translations=t_samp,
+        rotations=r_samp,
+        zooms=z_samp,
+        shears=s_samp,
+        dmax=d_samp,
+        steps=steps,
+        order=order,
+        patch=patch
+    )(x)
+    y.sum().backward()
+    assert (
+        (d.grad is not None) and
+        (t.grad is not None) and
+        (r.grad is not None) and
+        (z.grad is not None) and
+        (s.grad is not None)
+    ), [
+        k for k, v in {'d': d, 't': t, 'r': r, 'z': z, 's': z}.items()
+        if v.grad is None
+    ]

--- a/cornucopia/tests/test_backward_intensity.py
+++ b/cornucopia/tests/test_backward_intensity.py
@@ -1,0 +1,243 @@
+import pytest
+import random
+import torch
+from cornucopia import (
+    AddValueTransform,
+    MulValueTransform,
+    AddMulTransform,
+    FillValueTransform,
+    ClipTransform,
+    AddFieldTransform,
+    MulFieldTransform,
+    RandomAddFieldTransform,
+    RandomMulFieldTransform,
+    RandomSlicewiseMulFieldTransform,
+    RandomMulTransform,
+    RandomAddTransform,
+    RandomAddMulTransform,
+    GammaTransform,
+    RandomGammaTransform,
+    ZTransform,
+    QuantileTransform,
+)
+import cornucopia.random as ccrand
+
+
+SEED = 12345678
+SIZE = (1, 32, 32)
+
+
+def test_backward_intensity_add():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    a = torch.full([], 1.0, requires_grad=True)
+    y = AddValueTransform(a)(x)
+    y.sum().backward()
+    assert a.grad is not None
+
+
+def test_backward_intensity_mul():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    a = torch.full([], 2.0, requires_grad=True)
+    y = MulValueTransform(a)(x)
+    y.sum().backward()
+    assert a.grad is not None
+
+
+def test_backward_intensity_addmul():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    a = torch.full([], 2.0, requires_grad=True)
+    b = torch.full([], 1.0, requires_grad=True)
+    y = AddMulTransform(a, b)(x)
+    y.sum().backward()
+    assert (a.grad is not None) and (b is not None)
+
+
+def test_backward_intensity_fill():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    a = torch.full([], 0.0, requires_grad=True)
+    y = FillValueTransform(x < 0.5, a)(x)
+    y.sum().backward()
+    assert a.grad is not None
+
+
+def test_backward_intensity_clip():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    a = torch.full([], 0.25, requires_grad=True)
+    b = torch.full([], 0.75, requires_grad=True)
+    y = ClipTransform(a, b)(x)
+    y.sum().backward()
+    assert (a.grad is not None) and (b is not None)
+
+
+@pytest.mark.parametrize("order", (1, 3))
+def test_backward_intensity_addfield(order):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    a = torch.full([], 0.0, requires_grad=True)
+    b = torch.full([], 1.0, requires_grad=True)
+    y = AddFieldTransform(vmin=a, vmax=b, order=order)(x)
+    y.sum().backward()
+    assert (a.grad is not None) and (b is not None)
+
+
+@pytest.mark.parametrize("order", (1, 3))
+def test_backward_intensity_mulfield(order):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    a = torch.full([], 0.0, requires_grad=True)
+    b = torch.full([], 1.0, requires_grad=True)
+    y = MulFieldTransform(vmin=a, vmax=b, order=order)(x)
+    y.sum().backward()
+    assert (a.grad is not None) and (b is not None)
+
+
+@pytest.mark.parametrize("order", (1, 3))
+@pytest.mark.parametrize("shared", (True, False))
+def test_backward_intensity_addfield_random(order, shared):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    a = torch.full([], 1.0, requires_grad=True)
+    b = torch.full([], 2.0, requires_grad=True)
+    a_samp = ccrand.Uniform(0, a)
+    b_samp = ccrand.Uniform(1, b)
+    y = RandomAddFieldTransform(
+        vmin=a_samp, vmax=b_samp, order=order, shared=shared
+    )(x)
+    y.sum().backward()
+    assert (a.grad is not None) and (b is not None)
+
+
+@pytest.mark.parametrize("order", (1, 3))
+@pytest.mark.parametrize("shared", (True, False))
+def test_backward_intensity_mulfield_random(order, shared):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    a = torch.full([], 1.0, requires_grad=True)
+    a_samp = ccrand.Uniform(0, a)
+    y = RandomMulFieldTransform(
+        vmax=a_samp, order=order, shared=shared
+    )(x)
+    y.sum().backward()
+    assert (a.grad is not None)
+
+
+@pytest.mark.parametrize("order", (1, 3))
+@pytest.mark.parametrize("shared", (True, False))
+def test_backward_intensity_mulfield_slicewise_random(order, shared):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    a = torch.full([], 1.0, requires_grad=True)
+    a_samp = ccrand.Uniform(0, a)
+    y = RandomSlicewiseMulFieldTransform(
+        vmax=a_samp, order=order, shared=shared
+    )(x)
+    y.sum().backward()
+    assert (a.grad is not None)
+
+
+@pytest.mark.parametrize("shared", (True, False))
+def test_backward_intensity_add_random(shared):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    a = torch.full([], 1.0, requires_grad=True)
+    a_samp = ccrand.Uniform(0, a)
+    y = RandomAddTransform(a_samp, shared=shared)(x)
+    y.sum().backward()
+    assert (a.grad is not None)
+
+
+@pytest.mark.parametrize("shared", (True, False))
+def test_backward_intensity_mul_random(shared):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    a = torch.full([], 1.0, requires_grad=True)
+    a_samp = ccrand.Uniform(0, a)
+    y = RandomMulTransform(a_samp, shared=shared)(x)
+    y.sum().backward()
+    assert (a.grad is not None)
+
+
+@pytest.mark.parametrize("shared", (True, False))
+def test_backward_intensity_addmul_random(shared):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    a = torch.full([], 1.0, requires_grad=True)
+    a_samp = ccrand.Uniform(0, a)
+    y = RandomAddMulTransform(a_samp, shared=shared)(x)
+    y.sum().backward()
+    assert (a.grad is not None)
+
+
+def test_backward_intensity_gamma():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    a = torch.full([], 0.5, requires_grad=True)
+    y = GammaTransform(a)(x)
+    y.sum().backward()
+    assert (a.grad is not None)
+
+
+@pytest.mark.parametrize("shared", (True, False))
+def test_backward_intensity_gamma_random(shared):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    a = torch.full([], 1.0, requires_grad=True)
+    a_samp = ccrand.Uniform(0, a)
+    y = RandomGammaTransform(a_samp, shared=shared)(x)
+    y.sum().backward()
+    assert (a.grad is not None)
+
+
+@pytest.mark.parametrize("shared", (True, False))
+def test_backward_intensity_ztransform(shared):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    m = torch.full([], 0.0, requires_grad=True)
+    s = torch.full([], 1.0, requires_grad=True)
+    y = ZTransform(mu=m, sigma=s, shared=shared)(x)
+    y.sum().backward()
+    assert (m.grad is not None) and (s.grad is not None)
+
+
+def test_backward_intensity_quantile():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    q0 = torch.full([], -1.0, requires_grad=True)
+    q1 = torch.full([],  1.0, requires_grad=True)
+    mn = torch.full([], 0.0, requires_grad=True)
+    mx = torch.full([], 1.0, requires_grad=True)
+    y = QuantileTransform(
+        pmin=q0.sigmoid(), pmax=q1.sigmoid(), vmin=mn, vmax=mx
+    )(x)
+    y.sum().backward()
+    assert (
+        (q0.grad is not None) and
+        (q1.grad is not None) and
+        (mn.grad is not None) and
+        (mx.grad is not None)
+    ), [
+        k for k, v in {'q0': q0, 'q1': q1, 'mn': mn, 'mx': mx}.items()
+        if v.grad is None
+    ]

--- a/cornucopia/tests/test_backward_kspace.py
+++ b/cornucopia/tests/test_backward_kspace.py
@@ -13,7 +13,7 @@ SEED = 12345678
 SIZE = (1, 32, 32)
 
 
-def test_run_kspace_coils():
+def test_backward_kspace_coils():
     random.seed(SEED)
     torch.random.manual_seed(SEED)
     f = torch.full([], 0.5, requires_grad=True)
@@ -29,7 +29,7 @@ def test_run_kspace_coils():
     )
 
 
-def test_run_kspace_ssq():
+def test_backward_kspace_ssq():
     random.seed(SEED)
     torch.random.manual_seed(SEED)
     x = torch.randn(SIZE)
@@ -51,7 +51,7 @@ def test_run_kspace_ssq():
 @pytest.mark.parametrize("pattern", ('sequential', 'random'))
 @pytest.mark.parametrize("axis", (1, -1))
 @pytest.mark.parametrize("freq", (True, False))
-def test_run_kspace_motion(pattern, axis, freq):
+def test_backward_kspace_motion(pattern, axis, freq):
     random.seed(SEED)
     torch.random.manual_seed(SEED)
     x = torch.randn(SIZE)
@@ -71,7 +71,7 @@ def test_run_kspace_motion(pattern, axis, freq):
     )
 
 
-def test_run_kspace_motion_coils():
+def test_backward_kspace_motion_coils():
     random.seed(SEED)
     torch.random.manual_seed(SEED)
     x = torch.randn(SIZE)
@@ -97,7 +97,7 @@ def test_run_kspace_motion_coils():
 
 
 @pytest.mark.parametrize("axis", (1, -1))
-def test_run_kspace_motion_small(axis):
+def test_backward_kspace_motion_small(axis):
     random.seed(SEED)
     torch.random.manual_seed(SEED)
     x = torch.randn(SIZE)

--- a/cornucopia/tests/test_backward_kspace.py
+++ b/cornucopia/tests/test_backward_kspace.py
@@ -1,0 +1,115 @@
+import pytest
+import random
+import torch
+from cornucopia import (
+    ArrayCoilTransform,
+    SumOfSquaresTransform,
+    IntraScanMotionTransform,
+    SmallIntraScanMotionTransform,
+)
+
+
+SEED = 12345678
+SIZE = (1, 32, 32)
+
+
+def test_run_kspace_coils():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    f = torch.full([], 0.5, requires_grad=True)
+    d = torch.full([], 0.8, requires_grad=True)
+    j = torch.full([], 0.01, requires_grad=True)
+    x = torch.randn(SIZE)
+    y = ArrayCoilTransform(fwhm=f, diameter=d, jitter=j)(x)
+    y.abs().sum().backward()
+    assert (
+        (f.grad is not None) and
+        (d.grad is not None) and
+        (j.grad is not None)
+    )
+
+
+def test_run_kspace_ssq():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    f = torch.full([], 0.5, requires_grad=True)
+    d = torch.full([], 0.8, requires_grad=True)
+    j = torch.full([], 0.01, requires_grad=True)
+    y = ArrayCoilTransform(
+        fwhm=f, diameter=d, jitter=j, returns='uncombined'
+    )(x)
+    z = SumOfSquaresTransform()(y)
+    z.sum().backward()
+    assert (
+        (f.grad is not None) and
+        (d.grad is not None) and
+        (j.grad is not None)
+    )
+
+
+@pytest.mark.parametrize("pattern", ('sequential', 'random'))
+@pytest.mark.parametrize("axis", (1, -1))
+@pytest.mark.parametrize("freq", (True, False))
+def test_run_kspace_motion(pattern, axis, freq):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    t = torch.full([], 0.1, requires_grad=True)
+    r = torch.full([], 15.0, requires_grad=True)
+    y = IntraScanMotionTransform(
+        translations=t,
+        rotations=r,
+        pattern=pattern,
+        axis=axis,
+        freq=freq,
+    )(x)
+    y.sum().backward()
+    assert (
+        (t.grad is not None) and
+        (r.grad is not None)
+    )
+
+
+def test_run_kspace_motion_coils():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    t = torch.full([], 0.1, requires_grad=True)
+    r = torch.full([], 15.0, requires_grad=True)
+    f = torch.full([], 0.5, requires_grad=True)
+    d = torch.full([], 0.8, requires_grad=True)
+    j = torch.full([], 0.01, requires_grad=True)
+    c = ArrayCoilTransform(fwhm=f, diameter=d, jitter=j)
+    y = IntraScanMotionTransform(
+        translations=t,
+        rotations=r,
+        coils=c
+    )(x)
+    y.sum().backward()
+    assert (
+        (f.grad is not None) and
+        (d.grad is not None) and
+        (j.grad is not None) and
+        (t.grad is not None) and
+        (r.grad is not None)
+    )
+
+
+@pytest.mark.parametrize("axis", (1, -1))
+def test_run_kspace_motion_small(axis):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    t = torch.full([], 0.05, requires_grad=True)
+    r = torch.full([], 5.0,  requires_grad=True)
+    y = SmallIntraScanMotionTransform(
+        translations=t,
+        rotations=r,
+        axis=axis,
+    )(x)
+    y.sum().backward()
+    assert (
+        (t.grad is not None) and
+        (r.grad is not None)
+    )

--- a/cornucopia/tests/test_backward_noise.py
+++ b/cornucopia/tests/test_backward_noise.py
@@ -124,7 +124,7 @@ def test_backward_noise_gaussian_gfactor(shared, shared_field):
 
 @pytest.mark.parametrize("shared", [True, False])
 @pytest.mark.parametrize("shared_field", [True, False])
-def test_backward_noise_chi_gfactor(size, shared, shared_field):
+def test_backward_noise_chi_gfactor(shared, shared_field):
     random.seed(SEED)
     torch.random.manual_seed(SEED)
     x = torch.zeros(SIZE)
@@ -138,7 +138,10 @@ def test_backward_noise_chi_gfactor(size, shared, shared_field):
         (s.grad is not None) and
         (mn.grad is not None) and
         (mx.grad is not None)
-    )
+    ),  [
+        k for k, v in {'s': s, 'mn': mn, 'mx': mx}.items()
+        if v.grad is None
+    ]
 
 
 @pytest.mark.parametrize("shared", [True, False])
@@ -160,4 +163,7 @@ def test_backward_noise_chi_random_gfactor(shared, shared_noise, shared_field):
         (s.grad is not None) and
         (mn.grad is not None) and
         (mx.grad is not None)
-    )
+    ), [
+        k for k, v in {'s': s, 'mn': mn, 'mx': mx}.items()
+        if v.grad is None
+    ]

--- a/cornucopia/tests/test_backward_noise.py
+++ b/cornucopia/tests/test_backward_noise.py
@@ -1,0 +1,163 @@
+import pytest
+import random
+import torch
+from cornucopia import (
+    GaussianNoiseTransform,
+    RandomGaussianNoiseTransform,
+    ChiNoiseTransform,
+    RandomChiNoiseTransform,
+    GammaNoiseTransform,
+    RandomGammaNoiseTransform,
+    GFactorTransform,
+)
+
+
+SEED = 12345678
+SIZE = (2, 32, 32)
+
+
+@pytest.mark.parametrize("shared", [True, False])
+def test_backward_noise_gaussian(shared):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.zeros(SIZE)
+    s = torch.full([], 0.1, requires_grad=True)
+    y = GaussianNoiseTransform(sigma=s, shared=shared)(x)
+    y.sum().backward()
+    assert s.grad is not None
+
+
+@pytest.mark.parametrize("shared", [True, False])
+@pytest.mark.parametrize("shared_noise", [True, False])
+def test_backward_noise_gaussian_random(shared, shared_noise):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.zeros(SIZE)
+    s = torch.full([], 0.2, requires_grad=True)
+    y = RandomGaussianNoiseTransform(
+        sigma=s,
+        shared=shared,
+        shared_noise=shared_noise
+    )(x)
+    y.sum().backward()
+    assert s.grad is not None
+
+
+@pytest.mark.parametrize("shared", [True, False])
+def test_backward_noise_chi(shared):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.zeros(SIZE)
+    s = torch.full([], 0.1, requires_grad=True)
+    y = ChiNoiseTransform(sigma=s, shared=shared)(x)
+    y.sum().backward()
+    assert s.grad is not None
+
+
+@pytest.mark.parametrize("shared", [True, False])
+@pytest.mark.parametrize("shared_noise", [True, False])
+def test_backward_noise_chi_random(shared, shared_noise):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.zeros(SIZE)
+    s = torch.full([], 0.2, requires_grad=True)
+    y = RandomChiNoiseTransform(
+        sigma=s,
+        shared=shared,
+        shared_noise=shared_noise
+    )(x)
+    y.sum().backward()
+    assert s.grad is not None
+
+
+@pytest.mark.parametrize("shared", [True, False])
+def test_backward_noise_gamma(shared):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.ones(SIZE)
+    s = torch.full([], 0.1, requires_grad=True)
+    m = torch.full([], 1.0, requires_grad=True)
+    y = GammaNoiseTransform(sigma=s, mean=m, shared=shared)(x)
+    y.sum().backward()
+    assert (s.grad is not None) and (m.grad is not None)
+
+
+@pytest.mark.parametrize("shared", [True, False])
+@pytest.mark.parametrize("shared_noise", [True, False])
+def test_backward_noise_gamma_random(shared, shared_noise):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.zeros(SIZE)
+    s = torch.full([], 0.2, requires_grad=True)
+    m = torch.full([], 2.0, requires_grad=True)
+    y = RandomGammaNoiseTransform(
+        sigma=s,
+        mean=m,
+        shared=shared,
+        shared_noise=shared_noise
+    )(x)
+    y.sum().backward()
+    assert (s.grad is not None) and (m.grad is not None)
+
+
+@pytest.mark.parametrize("shared", [True, False])
+@pytest.mark.parametrize("shared_field", [True, False])
+def test_backward_noise_gaussian_gfactor(shared, shared_field):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.zeros(SIZE)
+    s = torch.full([], 0.1, requires_grad=True)
+    mn = torch.full([], 0.5, requires_grad=True)
+    mx = torch.full([], 1.5, requires_grad=True)
+    noise = GaussianNoiseTransform(sigma=s, shared=shared)
+    y = GFactorTransform(noise, vmin=mn, vmax=mx, shared=shared_field)(x)
+    y.sum().backward()
+    assert (
+        (s.grad is not None) and
+        (mn.grad is not None) and
+        (mx.grad is not None)
+    ), [
+        k for k, v in {'s': s, 'mn': mn, 'mx': mx}.items()
+        if v.grad is None
+    ]
+
+
+@pytest.mark.parametrize("shared", [True, False])
+@pytest.mark.parametrize("shared_field", [True, False])
+def test_backward_noise_chi_gfactor(size, shared, shared_field):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.zeros(SIZE)
+    s = torch.full([], 0.1, requires_grad=True)
+    mn = torch.full([], 0.5, requires_grad=True)
+    mx = torch.full([], 1.5, requires_grad=True)
+    noise = ChiNoiseTransform(sigma=s, shared=shared)
+    y = GFactorTransform(noise, vmin=mn, vmax=mx, shared=shared_field)(x)
+    y.sum().backward()
+    assert (
+        (s.grad is not None) and
+        (mn.grad is not None) and
+        (mx.grad is not None)
+    )
+
+
+@pytest.mark.parametrize("shared", [True, False])
+@pytest.mark.parametrize("shared_noise", [True, False])
+@pytest.mark.parametrize("shared_field", [True, False])
+def test_backward_noise_chi_random_gfactor(shared, shared_noise, shared_field):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.zeros(SIZE)
+    s = torch.full([], 0.2, requires_grad=True)
+    mn = torch.full([], 0.5, requires_grad=True)
+    mx = torch.full([], 1.5, requires_grad=True)
+    noise = RandomChiNoiseTransform(
+        sigma=s, shared=shared, shared_noise=shared_noise
+    )
+    y = GFactorTransform(noise, vmin=mn, vmax=mx, shared=shared_field)(x)
+    y.sum().backward()
+    assert (
+        (s.grad is not None) and
+        (mn.grad is not None) and
+        (mx.grad is not None)
+    )

--- a/cornucopia/tests/test_backward_psf.py
+++ b/cornucopia/tests/test_backward_psf.py
@@ -1,0 +1,143 @@
+import pytest
+import random
+import torch
+from cornucopia import (
+    SmoothTransform,
+    RandomSmoothTransform,
+    LowResTransform,
+    RandomLowResTransform,
+    LowResSliceTransform,
+    RandomLowResSliceTransform,
+    RandomChiNoiseTransform,
+)
+
+# NOTE / TODO
+#   The "low res" layers use torch.interpol under the hood, whose
+#   scaling factor depends on the input and target sizes. There is
+#   therefore no way to properly backpropagate through the resolution
+#   (currently, we "cheat" by first smoothing the image by the resolution,
+#   so there are some gradients flowing, but we're missing stuff).
+#   We could fix that by reimplementing `interpol` using `sample_grid`,
+#   and compute the flow field from the resolution parameter directly
+#   (rather than go "resolution -> target size -> flow field", since
+#   "resolution -> target_size" breaks the graph).
+
+
+SEED = 12345678
+SIZE = (2, 32, 32)
+
+
+def test_backward_psf_smooth():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.zeros(SIZE)
+    f = torch.full([], 1.0, requires_grad=True)
+    y = SmoothTransform(fwhm=f)(x)
+    y.sum().backward()
+    assert (f.grad is not None)
+
+
+@pytest.mark.parametrize("shared", [True, False])
+def test_backward_psf_smooth_random(shared):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.zeros(SIZE)
+    f = torch.full([], 1.0, requires_grad=True)
+    y = RandomSmoothTransform(fwhm=f, shared=shared)(x)
+    y.sum().backward()
+    assert (f.grad is not None)
+
+
+def test_backward_psf_lowres():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.zeros(SIZE)
+    r = torch.full([], 5.0, requires_grad=True)
+    y = LowResTransform(resolution=r)(x)
+    y.sum().backward()
+    assert (r.grad is not None)
+
+
+def test_backward_psf_lowres_noise():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    noise = RandomChiNoiseTransform()
+    x = torch.zeros(SIZE)
+    r = torch.full([], 5.0, requires_grad=True)
+    y = LowResTransform(resolution=r, noise=noise)(x)
+    y.sum().backward()
+    assert (r.grad is not None)
+
+
+@pytest.mark.parametrize("shared", [True, False])
+def test_backward_psf_lowres_random(shared):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.zeros(SIZE)
+    r = torch.full([], 5.0, requires_grad=True)
+    y = RandomLowResTransform(resolution=r, shared=shared)(x)
+    y.sum().backward()
+    assert (r.grad is not None)
+
+
+@pytest.mark.parametrize("shared", [True, False])
+def test_backward_psf_lowres_noise_random(shared):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    noise = RandomChiNoiseTransform()
+    x = torch.zeros(SIZE)
+    r = torch.full([], 5.0, requires_grad=True)
+    y = RandomLowResTransform(resolution=r, noise=noise, shared=shared)(x)
+    y.sum().backward()
+    assert (r.grad is not None)
+
+
+def test_backward_psf_slicelowres():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.zeros(SIZE)
+    r = torch.full([], 5.0, requires_grad=True)
+    t = torch.full([], 0.5, requires_grad=True)
+    y = LowResSliceTransform(resolution=r, thickness=t)(x)
+    print(x)
+    y.sum().backward()
+    assert (r.grad is not None) and (t.grad is not None)
+
+
+def test_backward_psf_slicelowres_noise():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    noise = RandomChiNoiseTransform()
+    x = torch.zeros(SIZE)
+    r = torch.full([], 5.0, requires_grad=True)
+    t = torch.full([], 0.5, requires_grad=True)
+    y = LowResSliceTransform(resolution=r, thickness=t, noise=noise)(x)
+    y.sum().backward()
+    assert (r.grad is not None) and (t.grad is not None)
+
+
+@pytest.mark.parametrize("shared", [True, False])
+def test_backward_psf_slicelowres_random(shared):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.zeros(SIZE)
+    r = torch.full([], 5.0, requires_grad=True)
+    t = torch.full([], 0.5, requires_grad=True)
+    y = RandomLowResSliceTransform(resolution=r, thickness=t, shared=shared)(x)
+    y.sum().backward()
+    assert (r.grad is not None) and (t.grad is not None)
+
+
+@pytest.mark.parametrize("shared", [True, False])
+def test_backward_psf_slicelowres_noise_random(shared):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    noise = RandomChiNoiseTransform()
+    x = torch.zeros(SIZE)
+    r = torch.full([], 5.0, requires_grad=True)
+    t = torch.full([], 0.5, requires_grad=True)
+    y = RandomLowResSliceTransform(
+        resolution=r, thickness=t, noise=noise, shared=shared
+    )(x)
+    y.sum().backward()
+    assert (r.grad is not None) and (t.grad is not None)

--- a/cornucopia/tests/test_backward_qmri.py
+++ b/cornucopia/tests/test_backward_qmri.py
@@ -1,0 +1,249 @@
+import pytest
+import random
+import torch
+from cornucopia import (
+    RandomSusceptibilityMixtureTransform,
+    SusceptibilityToFieldmapTransform,
+    ShimTransform,
+    OptimalShimTransform,
+    RandomShimTransform,
+    GradientEchoTransform,
+    RandomGMMGradientEchoTransform,
+    SmoothLabelMap,
+)
+
+torch.autograd.set_detect_anomaly(True)
+
+SEED = 12345678
+SIZE = (2, 32, 32)
+SIZE3D = (2, 32, 32, 32)
+
+
+@pytest.mark.parametrize("shared", [True, False])
+def test_backward_qmri_susceptibility(shared):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.zeros([]).expand(SIZE)
+    x = SmoothLabelMap(nb_classes=3)(x)
+    mt = torch.full([], 9.5, requires_grad=True)
+    st = torch.full([], 0.01, requires_grad=True)
+    mb = torch.full([], 12.5, requires_grad=True)
+    sb = torch.full([], 0.1, requires_grad=True)
+    f = torch.full([], 1.0, requires_grad=True)
+    y = RandomSusceptibilityMixtureTransform(
+        mu_tissue=mt,
+        sigma_tissue=st,
+        mu_bone=mb,
+        sigma_bone=sb,
+        fwhm=f,
+        label_air=1,
+        label_bone=2,
+        shared=shared
+    )(x)
+    y.sum().backward()
+    assert (
+        (mt.grad is not None) and
+        (st.grad is not None) and
+        (mb.grad is not None) and
+        (sb.grad is not None) and
+        (f.grad is not None)
+    ), [
+        k for k, v in {'mt': mt, 'st': st, 'mb': mb, 'sb': sb, 'f': f}.items()
+        if v.grad is None
+    ]
+
+
+def test_backward_qmri_tofieldmap():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.zeros(SIZE)
+    b = torch.full([], 3.0,         requires_grad=True)
+    f = torch.full([], 42.576E6,    requires_grad=True)
+    s0 = torch.full([], 0.4,        requires_grad=True)
+    s1 = torch.full([], 0.4,        requires_grad=True)
+    v = torch.full([], 1.0,         requires_grad=True)
+    x = SmoothLabelMap(nb_classes=1)(x).bool()
+    y = SusceptibilityToFieldmapTransform(
+        field_strength=b,
+        larmor=f,
+        s0=s0,
+        s1=s1,
+        voxel_size=v,
+    )(x)
+    y.sum().backward()
+    assert (
+        (b.grad is not None) and
+        (f.grad is not None) and
+        (s0.grad is not None) and
+        (s1.grad is not None) and
+        (v.grad is not None)
+    )
+
+
+@pytest.mark.parametrize("size", [SIZE, SIZE3D])
+def test_backward_qmri_shim(size):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.zeros([]).expand(size)
+    mt = torch.full([], 9.5,        requires_grad=True)
+    st = torch.full([], 0.01,       requires_grad=True)
+    mb = torch.full([], 12.5,       requires_grad=True)
+    sb = torch.full([], 0.1,        requires_grad=True)
+    fw = torch.full([], 1.0,        requires_grad=True)
+    b = torch.full([], 3.0,         requires_grad=True)
+    f = torch.full([], 42.576E6,    requires_grad=True)
+    s0 = torch.full([], 0.4,        requires_grad=True)
+    v = torch.full([], 1.0,         requires_grad=True)
+    x = SmoothLabelMap(nb_classes=3)(x)
+    x = RandomSusceptibilityMixtureTransform(
+        mu_tissue=mt,
+        sigma_tissue=st,
+        mu_bone=mb,
+        sigma_bone=sb,
+        fwhm=fw,
+        label_air=1,
+        label_bone=2,
+    )(x)
+    x = SusceptibilityToFieldmapTransform(
+        field_strength=b,
+        larmor=f,
+        s0=s0,
+        voxel_size=v,
+    )(x)
+    if x.ndim == 3:
+        linear = torch.randn([], requires_grad=True)
+        quad = torch.randn([], requires_grad=True)
+    else:
+        assert x.ndim == 4
+        linear = torch.randn([3], requires_grad=True)
+        quad = torch.randn([2], requires_grad=True)
+    y = ShimTransform(linear, quad)(x)
+    y.sum().backward()
+    assert (
+        (mt.grad is not None) and
+        (st.grad is not None) and
+        (mb.grad is not None) and
+        (sb.grad is not None) and
+        (fw.grad is not None) and
+        (b.grad is not None) and
+        (f.grad is not None) and
+        (s0.grad is not None) and
+        (v.grad is not None)
+    )
+
+
+def test_backward_qmri_shim_optimal():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.zeros([]).expand(SIZE)
+    mt = torch.full([], 9.5,        requires_grad=True)
+    st = torch.full([], 0.01,       requires_grad=True)
+    mb = torch.full([], 12.5,       requires_grad=True)
+    sb = torch.full([], 0.1,        requires_grad=True)
+    fw = torch.full([], 1.0,        requires_grad=True)
+    b = torch.full([], 3.0,         requires_grad=True)
+    f = torch.full([], 42.576E6,    requires_grad=True)
+    s0 = torch.full([], 0.4,        requires_grad=True)
+    v = torch.full([], 1.0,         requires_grad=True)
+    x = SmoothLabelMap(nb_classes=3)(x)
+    x = RandomSusceptibilityMixtureTransform(
+        mu_tissue=mt,
+        sigma_tissue=st,
+        mu_bone=mb,
+        sigma_bone=sb,
+        fwhm=fw,
+        label_air=1,
+        label_bone=2,
+    )(x)
+    x = SusceptibilityToFieldmapTransform(
+        field_strength=b,
+        larmor=f,
+        s0=s0,
+        voxel_size=v,
+    )(x)
+    y = OptimalShimTransform()(x)
+    y.sum().backward()
+    assert (
+        (mt.grad is not None) and
+        (st.grad is not None) and
+        (mb.grad is not None) and
+        (sb.grad is not None) and
+        (fw.grad is not None) and
+        (b.grad is not None) and
+        (f.grad is not None) and
+        (s0.grad is not None) and
+        (v.grad is not None)
+    )
+
+
+@pytest.mark.parametrize("shared", [True, False])
+def test_backward_qmri_shim_random(shared):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.zeros([]).expand(SIZE)
+    c = torch.full([], 5.0, requires_grad=True)
+    x = SmoothLabelMap(nb_classes=3)(x)
+    x = RandomSusceptibilityMixtureTransform()(x)
+    x = SusceptibilityToFieldmapTransform()(x)
+    y = RandomShimTransform(coefficients=c, shared=shared)(x)
+    y.sum().backward()
+    assert c.grad is not None
+
+
+def test_backward_qmri_gre():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    size = [5, *SIZE[1:]]  # channels must be MRI parameters
+    x = torch.randn(size).abs_()
+    x[-2] /= x[-2].max()
+    x[-1] *= 0.05 / x[-1].max()
+    x.requires_grad_()
+    tr = torch.full([], 25e-3, requires_grad=True)
+    te = torch.full([], 7e-3,  requires_grad=True)
+    fa = torch.full([], 20.0,  requires_grad=True)
+    b1 = torch.full([], 1.0,   requires_grad=True)
+    y = GradientEchoTransform(tr=tr, te=te, alpha=fa, b1=b1)(x)
+    y.sum().backward()
+    assert (
+        (x.grad is not None) and
+        (tr.grad is not None) and
+        (te.grad is not None) and
+        (fa.grad is not None) and
+        (b1.grad is not None)
+    )
+
+
+def test_backward_qmri_gre_random():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    size = [1, *SIZE[1:]]  # cannot be multi-channel
+    x = torch.zeros([]).expand(size)
+    tr = torch.full([], 25e-3,  requires_grad=True)
+    te = torch.full([], 7e-3,   requires_grad=True)
+    fa = torch.full([], 20.0,   requires_grad=True)
+    b1 = torch.full([], 1.0,    requires_grad=True)
+    pd = torch.full([], 1.0,    requires_grad=True)
+    t1 = torch.full([], 10.0,   requires_grad=True)
+    t2 = torch.full([], 100.0,  requires_grad=True)
+    mt = torch.full([], 0.1,    requires_grad=True)
+    s = torch.full([], 0.2,     requires_grad=True)
+    f = torch.full([], 2.0,     requires_grad=True)
+    x = SmoothLabelMap(nb_classes=5)(x)
+    y = RandomGMMGradientEchoTransform(
+        tr=tr, te=te, alpha=fa, b1=b1,
+        pd=pd, t1=t1, t2=t2, mt=mt,
+        sigma=s, fwhm=f,
+    )(x)
+    y.sum().backward()
+    assert (
+        (tr.grad is not None) and
+        (te.grad is not None) and
+        (fa.grad is not None) and
+        (b1.grad is not None) and
+        (t1.grad is not None) and
+        (t2.grad is not None) and
+        (pd.grad is not None) and
+        (mt.grad is not None) and
+        (s.grad is not None) and
+        (f.grad is not None)
+    )

--- a/cornucopia/tests/test_backward_random.py
+++ b/cornucopia/tests/test_backward_random.py
@@ -1,0 +1,44 @@
+import random
+import torch
+from cornucopia import random as ccrand
+
+SEED = 12345678
+
+
+def test_backward_random_fixed():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    a = torch.full([], 0.0, requires_grad=True)
+    r = ccrand.Fixed(a)
+    r().backward()
+    assert (a.grad is not None)
+
+
+def test_backward_random_uniform():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    a = torch.full([], 0.0, requires_grad=True)
+    b = torch.full([], 1.0, requires_grad=True)
+    r = ccrand.Uniform(a, b)
+    r().backward()
+    assert (a.grad is not None) and (b.grad is not None)
+
+
+def test_backward_random_normal():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    m = torch.full([], 0.0, requires_grad=True)
+    s = torch.full([], 1.0, requires_grad=True)
+    r = ccrand.Normal(m, s)
+    r().backward()
+    assert (m.grad is not None) and (s.grad is not None)
+
+
+def test_backward_random_lognormal():
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    m = torch.full([], 0.0, requires_grad=True)
+    s = torch.full([], 1.0, requires_grad=True)
+    r = ccrand.LogNormal(m, s)
+    r().backward()
+    assert (m.grad is not None) and (s.grad is not None)

--- a/cornucopia/tests/test_backward_synth.py
+++ b/cornucopia/tests/test_backward_synth.py
@@ -1,0 +1,72 @@
+import pytest
+import random
+import torch
+from cornucopia import (
+    IntensityTransform,
+    SynthFromLabelTransform,
+    SmoothLabelMap,
+)
+
+SEED = 12345678
+SIZE = (1, 32, 32)
+
+
+@pytest.mark.parametrize("order", [1, 3])
+def test_backward_synth_intensity(order):
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.randn(SIZE)
+    g = torch.full([], 0.6, requires_grad=True)
+    m = torch.full([], 3.0, requires_grad=True)
+    r = torch.full([], 8.0, requires_grad=True)
+    n = torch.full([], 10.0, requires_grad=True)
+    y = IntensityTransform(
+        gamma=g,
+        motion_fwhm=m,
+        resolution=r,
+        snr=n,
+        order=order,
+
+    )(x)
+    y.sum().backward()
+    assert (
+        (g.grad is not None) and
+        (m.grad is not None) and
+        (r.grad is not None) and
+        (n.grad is not None)
+    ), [
+        k for k, v in {'g': g, 'm': m, 'r': r, 'n': n}.items()
+        if v.grad is None
+    ]
+
+
+@pytest.mark.parametrize("patch", [None, 8])
+@pytest.mark.parametrize("affine", [False, True])
+@pytest.mark.parametrize("elastic_steps", [0, 7])
+def test_backward_synth_fromlabel(patch, affine, elastic_steps):
+    if not affine:
+        affine = dict(rotation=0, shears=0, zooms=0)
+    else:
+        affine = {}
+
+    random.seed(SEED)
+    torch.random.manual_seed(SEED)
+    x = torch.zeros([]).expand(SIZE)
+    f = torch.full([], 10.0, requires_grad=True)
+    d = torch.full([], 0.05, requires_grad=True)
+    x = SmoothLabelMap(soft=True)(x)
+    y, z = SynthFromLabelTransform(
+        patch=patch,
+        gmm_fwhm=f,
+        elastic=d,
+        elastic_steps=elastic_steps,
+        **affine,
+    )(x)
+    y.sum().backward()
+    assert (
+        (f.grad is not None) and
+        (d.grad is not None)
+    ),  [
+        k for k, v in {'f': f, 'd': d}.items()
+        if v.grad is None
+    ]

--- a/cornucopia/utils/conv.py
+++ b/cornucopia/utils/conv.py
@@ -1,4 +1,3 @@
-import torch
 from torch.nn import functional as F
 from .py import ensure_list
 from .padding import pad
@@ -54,18 +53,24 @@ def convnd(ndim, tensor, kernel, bias=None, stride=1, padding=0, bound='zero',
     batch = tensor.shape[:-(ndim+has_channels)]
     spatial_in = tensor.shape[(-ndim):]
     if has_channels and tensor.shape[-(ndim+has_channels)] != channels_in:
-        raise ValueError('Number of input channels not consistent: '
-                         'Got {} (kernel) and {} (tensor).' .format(
-                         channels_in, tensor.shape[-(ndim+has_channels)]))
+        raise ValueError(
+            'Number of input channels not consistent: '
+            'Got {} (kernel) and {} (tensor).'.format(
+                channels_in, tensor.shape[-(ndim+has_channels)]
+            )
+        )
     tensor = tensor.reshape([-1, channels_in, *spatial_in])
     if bias:
         bias = bias.flatten()
         if bias.numel() == 1:
             bias = bias.expand(channels_out)
         elif bias.numel() != channels_out:
-            raise ValueError('Number of output channels not consistent: '
-                             'Got {} (kernel) and {} (bias).' .format(
-                             channels_out, bias.numel()))
+            raise ValueError(
+                'Number of output channels not consistent: '
+                'Got {} (kernel) and {} (bias).' .format(
+                    channels_out, bias.numel()
+                )
+            )
 
     # Perform padding
     dilation = ensure_list(dilation, ndim)

--- a/cornucopia/utils/conv.py
+++ b/cornucopia/utils/conv.py
@@ -1,5 +1,5 @@
 from torch.nn import functional as F
-from .py import ensure_list
+from .py import ensure_list, make_vector
 from .padding import pad
 from .kernels import smoothing_kernel
 
@@ -256,7 +256,7 @@ def smoothnd(input, type='gauss', fwhm=1, basis=1, bound='dct2',
         This differs from the behaviour of torch's `conv*d`.
     """
     backend = dict(dtype=input.dtype, device=input.device)
-    fwhm = ensure_list(fwhm)
+    fwhm = make_vector(fwhm)
     if kernel is None or len(kernel) == 0:
         kernel = smoothing_kernel(type, fwhm, basis, **backend)
 

--- a/cornucopia/utils/py.py
+++ b/cornucopia/utils/py.py
@@ -70,7 +70,10 @@ def make_vector(input, n=None, crop=True, *args,
         default = kwargs['default']
     else:
         default = input[-1]
-    default = input.new_full([n-len(input)], default)
+    if torch.is_tensor(default):
+        default = torch.stack([default] * (n-len(input)))
+    else:
+        default = input.new_full([n-len(input)], default)
     return torch.cat([input, default])
 
 

--- a/cornucopia/utils/py.py
+++ b/cornucopia/utils/py.py
@@ -59,7 +59,21 @@ def make_vector(input, n=None, crop=True, *args,
         Output vector.
 
     """
-    input = torch.as_tensor(input, dtype=dtype, device=device).flatten()
+    if (
+        not torch.is_tensor(input) and
+        hasattr(input, '__iter__') and
+        any(map(torch.is_tensor, input))
+    ):
+        # we need to be careful if we want to preserve the graph
+        input = list(map(
+            lambda x: torch.as_tensor(x, dtype=dtype, device=device).flatten(),
+            input
+        ))
+        input = torch.cat(input)
+    else:
+        # either already a tensor, or a sequence of non-tensors,
+        # so we're fine
+        input = torch.as_tensor(input, dtype=dtype, device=device).flatten()
     if n is None:
         return input
     if n is not None and input.numel() >= n:

--- a/cornucopia/utils/smart_inplace.py
+++ b/cornucopia/utils/smart_inplace.py
@@ -1,0 +1,154 @@
+"""
+These are "smart" inplace operators that only operate inplace if doing
+so does not break the computational graph with respect to variables
+that require grad.
+
+Note that they should still be used carefully, as the overwritten tensors
+may be needed when backpropagating through other operations. For example,
+the following code would break the computational graph:
+
+```python
+x = torch.randn([])
+
+y = torch.randn([])
+y.requires_grad = True
+
+a = x.mul(y)    # mul requires x to be saved to bakpropagate through y
+b = x.add_(1)   # but we overwrite x here
+c = a + b
+
+c.backward()
+```
+
+whereas this would work
+
+```python
+x = torch.randn([])
+
+y = torch.randn([])
+y.requires_grad = True
+
+a = x.add(y)     # add does not need anythong to backpropagate
+b = x.add_(1)    # so we can overwrite x here
+c = a + b
+
+c.backward()
+```
+
+"""
+import math
+import torch
+
+
+def add_(x, y, **kwargs):
+    # d(x+a*y)/dx = 1
+    # d(x+a*y)/dy = a
+    # d(x+a*y)/da = y
+    # -> we can overwrite x
+    if not torch.is_tensor(x):
+        return x + y * kwargs.get('alpha', 1)
+    return x.add_(y, **kwargs)
+
+
+def sub_(x, y, **kwargs):
+    # d(x-a*y)/dx = 1
+    # d(x-a*y)/dy = -a
+    # d(x-a*y)/da = -y
+    # -> we can overwrite x
+    if not torch.is_tensor(x):
+        return x - y * kwargs.get('alpha', 1)
+    return x.sub_(y, **kwargs)
+
+
+def mul_(x, y, **kwargs):
+    # d(x*y)/dx = y
+    # d(x*y)/dy = x
+    # -> we can overwrite x if we do not backprop through y
+    if not torch.is_tensor(x):
+        return x * y
+    return (
+        x.mul(y, **kwargs) if getattr(y, 'requires_grad', False) else
+        x.mul_(y, **kwargs)
+    )
+
+
+def div_(x, y, **kwargs):
+    # d(x/y)/dx = 1/y
+    # d(x/y)/dy = -x/y**2
+    # -> we can overwrite x if we do not backprop through y
+    if not torch.is_tensor(x):
+        return x / y
+    return (
+        x.div(y, **kwargs) if getattr(y, 'requires_grad', False) else
+        x.div_(y, **kwargs)
+    )
+
+
+def pow_(x, y, **kwargs):
+    # d(x**y)/dx = y * x**(y-1)
+    # d(x**y)/dy = (x**y) * log(|x|) * sign(x)**y
+    # -> we can overwrite x if we do not backprop through x or y
+    if not torch.is_tensor(x):
+        return x ** y
+    inplace = not (x.requires_grad or getattr(y, 'requires_grad', False))
+    return x.pow(y, **kwargs) if not inplace else x.pow_(y, **kwargs)
+
+
+def square_(x, **kwargs):
+    # d(x**2)/dx = 2*x
+    # -> we can overwrite x if we do not backprop through x
+    if not torch.is_tensor(x):
+        return x * x
+    return x.square(**kwargs) if x.requires_grad else x.square_(**kwargs)
+
+
+def sqrt_(x, **kwargs):
+    # d(x**0.5)/dx = 0.5*x
+    # -> we can overwrite x if we do not backprop through x
+    if not torch.is_tensor(x):
+        return x ** 0.5
+    return x.sqrt(**kwargs) if x.requires_grad else x.sqrt_(**kwargs)
+
+
+def atan2_(x, y, **kwargs):
+    if not torch.is_tensor(x) and not torch.is_tensor(y):
+        return math.atan2(x, y)
+    if not torch.is_tensor(x):
+        x = torch.as_tensor(x, dtype=y.dtype, device=y.device)
+    if not torch.is_tensor(y):
+        y = torch.as_tensor(y, dtype=x.dtype, device=x.device)
+    inplace = not (x.requires_grad or y.requires_grad)
+    return x.atan2(y, **kwargs) if not inplace else x.atan2_(y, **kwargs)
+
+
+def neg_(x, **kwargs):
+    if not torch.is_tensor(x):
+        return -x
+    return x.neg_(**kwargs)
+
+
+def reciprocal_(x, **kwargs):
+    if not torch.is_tensor(x):
+        return 1/x
+    return (
+        x.reciprocal(**kwargs) if x.requires_grad else
+        x.reciprocal_(**kwargs)
+    )
+
+
+def abs_(x, **kwargs):
+    if not torch.is_tensor(x):
+        return abs(x)
+    return x.abs(**kwargs) if x.requires_grad else x.abs_(**kwargs)
+
+
+def exp_(x, **kwargs):
+    if not torch.is_tensor(x):
+        return math.exp(x)
+    return x.exp(**kwargs) if x.requires_grad else x.exp_(**kwargs)
+
+
+def log_(x, **kwargs):
+    if not torch.is_tensor(x):
+        return math.log(x)
+    return x.log(**kwargs) if x.requires_grad else x.log_(**kwargs)

--- a/cornucopia/utils/smart_inplace.py
+++ b/cornucopia/utils/smart_inplace.py
@@ -152,3 +152,9 @@ def log_(x, **kwargs):
     if not torch.is_tensor(x):
         return math.log(x)
     return x.log(**kwargs) if x.requires_grad else x.log_(**kwargs)
+
+
+def atan_(x, **kwargs):
+    if not torch.is_tensor(x):
+        return math.atan(x)
+    return x.atan(**kwargs) if x.requires_grad else x.atan_(**kwargs)


### PR DESCRIPTION
I make heavy use of in-place operations in cornucopia, because they bring quite a significant speedup in my experience (they save a few allocations -- although pytorch tends to not free its allocated memory and reuse it through its own allocator -- and minimize memory fragmentation).

The issue is that in many case, these inplace operations break the computational graph, and it is therefore impossible to backpropagate through them.

I always thought of cornucopia as an augmentation library, and therefore did not care much about backpropagating through its layers. However, with [Learn2Synth](https://arxiv.org/abs/2411.16719), it now makse sense to packpropagate through augmentation and synthesis layers. 

This PR fixes all in-place operations. Rather than replacing them with out-of-place ones, I toggle in-place/out-of-place depending on whether gradients need tracking or not. It's a bit more tedious, but I've written a test suite and it seems to work properly.

Note that although we _can_ backpropagate through all layers (i.e., gradients get computed), it does not mean that we _properly_ backpropagate. For example:

-  The `LowResTransform` and `LowResSliceTransform` layers use `torch.interpol` to downsample/upsample the data, and this operator does not backpropagate through the upsampling factor. We should rewrite the interpolation operation using `torch.sample_grid` so that the upsampling factor is differentiable
- None of the layers that act on label maps are differentiable. We could come up with differentiable versions if we replace thresholding/masking with soft versions (e.g., squeeze energies through a sigmoid and add them, instead of using `mask_fill_`).
- Similarly, deforming label maps does not allow to backprop through the deformation field -- and this is something that we often do in SynthSeg. Again, we could use a soft version instead of nearest-neighbor/linear-argmax interpolation.

These problems are left for a future PR.