### PR TITLE
Fix: RandInt error when _use_torch=True

### DIFF
--- a/cornucopia/random.py
+++ b/cornucopia/random.py
@@ -255,9 +255,8 @@ class RandInt(Sampler):
     def __call__(self, n=None, **backend):
         if self._use_torch(n):
             n = tuple(ensure_list(n or []))
-            return torch.randint(
-                1 + self.max - self.min, n, **backend
-            ).add_(self.min)
+            backend.setdefault('device', getattr(self.max - self.min, 'device', None))
+            return torch.randint(low=self.min, high=1 + self.max, size=n, **backend)
         return self.map(random.randint, self.min, self.max, n=n)
 
 


### PR DESCRIPTION
This PR fixes an error in the RandInt class in random.py that occurred when _use_torch was set to True. The issue was due to torch.randint defaulting to the 'cpu' device, even when the input arguments were GPU tensors. This caused a device mismatch error during runtime. The fix ensures that torch.randint explicitly uses the correct device. It also simplifies the logic by using the low argument of torch.randint, instead of the previous min/max trick.